### PR TITLE
Gem packager

### DIFF
--- a/lib/bozo/packagers/gem.rb
+++ b/lib/bozo/packagers/gem.rb
@@ -9,19 +9,14 @@ module Bozo::Packagers
       dist_dir = File.expand_path(File.join('dist', 'gem'))
       FileUtils.mkdir_p dist_dir
 
-      gemspecs = []
-      Dir['*.gemspec'].each { |file| gemspecs << File.expand_path(file) }
-
-      gemspecs.each do |spec|
-        args = []
-        args << 'gem'
-        args << 'build'
-        args << spec
-
-        execute_command :gem, args
-      end
-
+      Dir['*.gemspec'].each { |spec| build_gem spec }
       Dir['*.gem'].each { |file| FileUtils.mv file, File.join(dist_dir, file) }
+    end
+
+    private
+
+    def build_gem(spec)
+      execute_command :gem, ['gem', 'build', spec]
     end
 
   end


### PR DESCRIPTION
Removed the chdir when building the gem so that paths in the gemspec file don't have to be defined relative to the dist/gem path
