### PR TITLE
raises an error if no rtest files were found

### DIFF
--- a/lib/bozo/test_runners/runit.rb
+++ b/lib/bozo/test_runners/runit.rb
@@ -20,7 +20,7 @@ module Bozo::TestRunners
       end
 
       # raise an error if no test files were found. This may indicate a configuration issue
-      raise "No tests found" unless test_files.any?
+      raise Bozo::ConfigurationError.new "No tests found" unless test_files.any?
       raise Bozo::ExecutionError.new(:runit, test_files, -1) unless execute_tests test_files
     end
 


### PR DESCRIPTION
I don't know if we want to raise a specific bozo error for this? ExecutionError doesn't make sense
