### PR TITLE
Initial stab at including the nuget dependencies in the nuspec file

### DIFF
--- a/lib/bozo/packagers/nuget.rb
+++ b/lib/bozo/packagers/nuget.rb
@@ -180,14 +180,16 @@ module Bozo::Packagers
     end
 
     def packages_file
-      file = File.expand_path(File.join('src', 'csharp', @name, 'packages.config'))
-      file = File.expand_path(File.join('test', 'csharp', @name, 'packages.config')) unless File.exist? file
-      file
+      find_file_in_project 'packages.config'
     end
 
     def project_file
-      file = File.expand_path(File.join('src', 'csharp', @name, "#{@name}.csproj"))
-      file = File.expand_path(File.join('test', 'csharp', @name, "#{@name}.csproj")) unless File.exist? file
+      find_file_in_project "#{@name}.csproj"
+    end
+
+    def find_file_in_project(file_name)
+      file = File.expand_path(File.join('src', 'csharp', @name, file_name))
+      file = File.expand_path(File.join('test', 'csharp', @name, file_name)) unless File.exist? file
       file
     end
 


### PR DESCRIPTION
It's a first stab so needs work to tidy it up and decide what to do about project references.

For library packages only the project.dll is included in the lib and any nuget package dependencies in the packages.config file are included in the generated nuspec
