### PR TITLE
add exclude and include command arguments

### DIFF
--- a/lib/bozo/test_runners/nunit.rb
+++ b/lib/bozo/test_runners/nunit.rb
@@ -39,10 +39,12 @@ module Bozo::TestRunners
     end
 
     def include(include)
+      cannot_define_both_include_and_exclude_categories if @exclude.any?
       @include << include
     end
 
     def exclude(exclude)
+      cannot_define_both_include_and_exclude_categories if @include.any?
       @exclude << exclude
     end
     
@@ -92,11 +94,6 @@ module Bozo::TestRunners
       FileUtils.mkdir_p File.dirname(report_path)
 
       args << "/xml:\"#{report_path}\""
-
-      if @include.any? && @exclude.any?
-        raise Bozo::ConfigurationError.new 'Both include and exclude categories defined. You cannot specify both for nunit.'
-      end
-
       args << "/include:#{@include.join(',')}" if @include.any?
       args << "/exclude:#{@exclude.join(',')}" if @exclude.any?
 
@@ -123,6 +120,10 @@ module Bozo::TestRunners
     
     def expand_and_glob(*args)
       Dir[expand_path(*args)]
+    end
+
+    def cannot_define_both_include_and_exclude_categories
+      raise Bozo::ConfigurationError.new 'Both include and exclude categories defined. You cannot specify both for nunit.'
     end
   
   end


### PR DESCRIPTION
Adds the `/exclude` and `/include` command arguments to the nunit test runner

:mag:
