### PR TITLE
Msbuild changes

### DIFF
--- a/lib/bozo/compilers/msbuild.rb
+++ b/lib/bozo/compilers/msbuild.rb
@@ -113,7 +113,7 @@ module Bozo::Compilers
         projects = projects.select { |p| @only_projects.include?(File.basename p, '.csproj') }
       end
 
-      projects.select { |p| not @exclude_projects.include?(File.basename p, '.csproj') }
+      projects.reject { |p| @exclude_projects.include?(File.basename p, '.csproj') }
     end
 
     def required_tools


### PR DESCRIPTION
- Renamed `version` to `clr_version`

In a repository you might want to use msbuild configured with different framework/version for different projects

`include_project` includes only those specifed projects, this can be used in conjunction with exclude_project (but that would be daft).

By default all projects are included

:mag: @gshutler 
