### PR TITLE
Allow bozo to include external/extra libraries in a nuget library package

### DIFF
--- a/lib/bozo/packagers/nuget.rb
+++ b/lib/bozo/packagers/nuget.rb
@@ -14,7 +14,7 @@ module Bozo::Packagers
       @destination = destination
     end
     
-    def library(project, extfiles = [])
+    def library(project, *extfiles)
       @libraries << LibraryPackage.new(project, extfiles, self)
     end
 


### PR DESCRIPTION
To include external libraries that may not have the same name as the project, you can include this in `bozorc.rb` 

```
p.library 'Zopa.Project1', 'SomeAPI.dll'
```

Or to include a few extra libraries

```
p.library 'Zopa.Project1', 'SomeAPI.dll', 'AnotherLib.dll'
```

This will make the `nuspec` file generated to include the libraries as additional files.
