### PR TITLE
Common assembly uses the build_version env variable

### DIFF
--- a/lib/bozo/hooks/build_number_version.rb
+++ b/lib/bozo/hooks/build_number_version.rb
@@ -2,22 +2,22 @@ module Bozo::Hooks
 
   class BuildNumberVersion
 
-  	def post_dependencies
+    def pre_prepare
       env['GIT_HASH_FULL'] = `git log -1 --format="%H"`.strip
-      env['BUILD_VERSION']= build_version
+      env['BUILD_VERSION'] = build_version
       build_version.write_to_file "NEW_VERSION"
     end
 
-  	private
+    private
 
-  	def build_version
-  	  if env['BUILD_NUMBER']
-  	  	Bozo::Versioning::Version.new(version.major, version.minor, env['BUILD_NUMBER'])
-  	  else
-  	  	version
-  	  end
-  	end
-  
+    def build_version
+      if env['BUILD_NUMBER']
+        Bozo::Versioning::Version.new(version.major, version.minor, env['BUILD_NUMBER'])
+      else
+      version
+      end
+    end
+
   end
 
 end

--- a/lib/bozo/hooks/git_commit_hashes.rb
+++ b/lib/bozo/hooks/git_commit_hashes.rb
@@ -2,7 +2,7 @@ module Bozo::Hooks
 
   class GitCommitHashes
     
-    def post_dependencies
+    def pre_prepare
       env['GIT_HASH'] = `git log -1 --format="%h"`.strip
       env['GIT_HASH_FULL'] = `git log -1 --format="%H"`.strip
       env['BUILD_VERSION'] = build_version

--- a/lib/bozo/preparers/common_assembly_info.rb
+++ b/lib/bozo/preparers/common_assembly_info.rb
@@ -13,8 +13,9 @@ module Bozo::Preparers
       computer_name = env['COMPUTERNAME']
       trademark = computer_name ? "#{computer_name} #{git_hash}" : git_hash
       path = File.expand_path(File.join('build', 'CommonAssemblyInfo.cs'))
+      build_version = env['BUILD_VERSION']
 
-      log_debug "Version: #{version}"
+      log_debug "Version: #{build_version}"
       log_debug "Commit hash: #{git_hash}"
       log_debug "Computer name: #{computer_name}" if computer_name
       log_debug "Path: #{path}"
@@ -23,8 +24,8 @@ module Bozo::Preparers
         f << "using System.Reflection;\n"
         f << "\n"
         f << "[assembly: AssemblyCompany(\"#{@company_name}\")]\n"
-        f << "[assembly: AssemblyVersion(\"#{version}\")]\n"
-        f << "[assembly: AssemblyFileVersion(\"#{version}\")]\n"
+        f << "[assembly: AssemblyVersion(\"#{build_version}\")]\n"
+        f << "[assembly: AssemblyFileVersion(\"#{build_version}\")]\n"
         f << "[assembly: AssemblyTrademark(\"#{trademark}\")]"
       end
     end


### PR DESCRIPTION
With the introduction of multiple version generators the CommonAssemblyInfo prepare step continued to use the version specified in the `version` file even when the version was generated with a different method.

This fixes the version hooks to run pre_prepare so the `BUILD_VERSION` environment value is available during the `CommonAssemblyInfo` step.
