### PR TITLE
Add ability to exclude files from templating

### DIFF
--- a/lib/bozo/preparers/file_templating.rb
+++ b/lib/bozo/preparers/file_templating.rb
@@ -153,15 +153,13 @@ module Bozo::Preparers
 
     # Adds the templates to the templating coordinator.
     def add_templates(coordinator)
+      exclude = @exclude_globs.map { |glob| Dir[glob] }.flatten
+
       @template_globs.each do |glob|
         Dir[glob].each do |file|
-          coordinator.template_file file unless excluded_file?(file)
+          coordinator.template_file file unless exclude.include?(file)
         end
       end
-    end
-
-    def excluded_file?(file)
-      @exclude_globs.any? { |glob| Dir[glob].include? (file) }
     end
 
   end

--- a/lib/bozo/preparers/file_templating.rb
+++ b/lib/bozo/preparers/file_templating.rb
@@ -22,6 +22,7 @@ module Bozo::Preparers
   #     t.config_path 'somewhere' # defaults to 'config' if not specified
   #     t.config_file 'my/specific/file.rb' # must be a specific file
   #     t.template_files 'src/**/*.config.template' # can use glob format
+  #     t.exclude_files 'src/**/obj/*' # can exclude specific files
   #   end
   #
   # Source files are expected to have an additional extension compared to the
@@ -69,6 +70,7 @@ module Bozo::Preparers
       @config_path = 'config'
       @template_globs = []
       @config_files = []
+      @exclude_globs = []
     end
 
     # Sets the path of the directory within which the preparer should look for
@@ -95,6 +97,15 @@ module Bozo::Preparers
     #     templating engine.
     def template_files(glob)
       @template_globs << glob
+    end
+
+    # Adds a set of templates files from which to exclude from templating.
+    #
+    # @param [String] glob
+    #     A glob that points to a set of files that should be excluded from
+    #     the templating engine.
+    def exclude_files(glob)
+      @exclude_globs << glob
     end
 
     # Generate all the files matching the configuration.
@@ -143,8 +154,14 @@ module Bozo::Preparers
     # Adds the templates to the templating coordinator.
     def add_templates(coordinator)
       @template_globs.each do |glob|
-        coordinator.template_files glob
+        Dir[glob].each do |file|
+          coordinator.template_file file unless excluded_file?(file)
+        end
       end
+    end
+
+    def excluded_file?(file)
+      @exclude_globs.any? { |glob| Dir[glob].include? (file) }
     end
 
   end


### PR DESCRIPTION
Useful when files may have been copied to other locations, such as the obj dir for .net websites

```
prepare :file_templating do |t|
  t.template_files '{src,test}/**/*.config.template'
  t.exclude_files '{src,test}/**/obj/**/*.config.template'
end
```

:mag: @stephenbinns 