### PR TITLE
Prevent TypeError when build_tools_location is not specified.

### DIFF
--- a/lib/bozo/compilers/msbuild.rb
+++ b/lib/bozo/compilers/msbuild.rb
@@ -98,10 +98,6 @@ module Bozo::Compilers
       Dir[project_file_matcher].select { |p| not @exclude_projects.include?(File.basename p, '.csproj') }
     end
 
-    def required_tools
-      :stylecop unless @config[:without_stylecop]
-    end
-
     private
 
     # Creates a project based on the project_file type.


### PR DESCRIPTION
StyleCop is included as a package so does not need to be retrieved from `build_tools_location`.  It should therefore be possible not to specify `build_tools_location` in `bozorc.rb`.  However, this was resulting in a TypeError similar to https://github.com/zopaUK/bozo/pull/33.  The reason is that `Msbuild` was declaring this as a required tool.  Removing the optional `required_tools` method fixes this.