### PR TITLE
Allow users to explicitly ignore nuget references specified

### DIFF
--- a/lib/bozo/packagers/nuget.rb
+++ b/lib/bozo/packagers/nuget.rb
@@ -19,7 +19,7 @@ module Bozo::Packagers
     end
 
     def library_with_option(project, opts = {})
-      @libraries << LibraryPackage.new(project, opts[:extfiles], self, opts[:excluded_packages])
+      @libraries << LibraryPackage.new(project, opts[:extfiles], self, opts[:excluded_references])
     end
 
     def executable(project)


### PR DESCRIPTION
This allows users to references packages in a library without enforcing these as dependencies within the nuget spec file

The problem being that a reference to stylecop/fxcop becomes a hard dependency downstream which can cause versioning woes if a consumer has a newer version

Usage

```ruby
package_with :nuget do |p|
  p.project_url 'http://www.zopa.com'
  p.license_url 'http://www.zopa.com'
  p.author 'Zopa Ltd'

  p.library_with_option 'AwesomeSharedLib', excluded_references: %w(StyleCop FxCop)
end

```