### PR TITLE
add logic that exclude developers packages from dependency

### DIFF
--- a/lib/bozo/packagers/nuget.rb
+++ b/lib/bozo/packagers/nuget.rb
@@ -213,9 +213,9 @@ module Bozo::Packagers
 
       doc = Nokogiri::XML(File.open(package_file))
 
-      doc.xpath('//packages/package').map do |node|
-        {:id => node[:id], :version => "[#{node[:version]}]"} unless @excluded_references.include? node[:id]
-      end
+      dependencies = doc.xpath('//packages/package').map do |node|
+        {:id => node[:id], :version => "[#{node[:version]}]"} unless (@excluded_references.include?(node[:id]) || node[:developmentDependency] == "true")
+      end.compact    
     end
 
     def packages_file


### PR DESCRIPTION
This should exclude all packages that are defined `@excluded_references` or has set true for `developmentDependency`.

This will prevent to package contains development dependencies that we don't want to have in projects that consume it. (like `stylecop.analizer`)

:mag: @lukesmith @lavapatch 